### PR TITLE
Proper prometheus_host resource

### DIFF
--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -304,7 +304,8 @@ class Prometheus::Base
       end
       ret.merge!( "#{param}" => value) 
     }
-    ret.merge!( "exporter_name" => "prometheus_#{self.name}_on_#{self.host}_port_#{self.port}")
+    exportername = "prometheus_#{self.name}_on_#{self.host}_port_#{self.port}"
+    ret.merge!( "exporter_name" => exportername)
     puts ret
     ret
   end

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -295,11 +295,11 @@ class Prometheus::Base
   end
 
   def to_hash
-    ret = { :targets => [ "#{self.host_name}:#{self.port}" ]}
+    ret = { :targets => [ "#{self.host}:#{self.port}" ]}
     @parameters.keys.sort.each { |param|
       value = @parameters[param]
       #puts "Key: #{param} - Value: #{value}"
-      if ["host_name","port"].include?(param)
+      if ["host","port"].include?(param)
         next
       end
       ret.merge!( "#{param}" => value) 
@@ -318,7 +318,7 @@ class Prometheus::Base
 
   # object types
   newtype :host do
-    setparameters :exporter_name, :host_name, :labels, :port
+    setparameters :exporter_name, :host, :labels, :port
   end
 
 end

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -304,6 +304,8 @@ class Prometheus::Base
       end
       ret.merge!( "#{param}" => value) 
     }
+    ret.merge! ( "exporter_name" => "prometheus_#{self.name}_on_#{self.host}_port_#{self.port}")
+    puts ret
     ret
   end
 

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -320,8 +320,8 @@ class Prometheus::Base
 
   # object types
   newtype :host do
-    setparameters :title, :host, :labels, :port
-    setnamevar :title
+    setparameters :exporter_name, :host, :labels, :port
+    setnamevar :exporter_name
   end
 
 end

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -320,7 +320,7 @@ class Prometheus::Base
 
   # object types
   newtype :host do
-    setparameters :exporter_name, :host, :labels, :port
+    setparameters :exporter_name, :host_name, :labels, :port
     setnamevar :exporter_name
   end
 

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -299,7 +299,7 @@ class Prometheus::Base
     @parameters.keys.sort.each { |param|
       value = @parameters[param]
       #puts "Key: #{param} - Value: #{value}"
-      if ["host_name","port"].include?(param)
+      if ["host_name","port","exporter_name"].include?(param)
         next
       end
       ret.merge!( "#{param}" => value) 

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -295,7 +295,7 @@ class Prometheus::Base
   end
 
   def to_hash
-    ret = { :targets => [ "#{self.host}:#{self.port}" ]}
+    ret = { :targets => [ "#{self.host_name}:#{self.port}" ]}
     @parameters.keys.sort.each { |param|
       value = @parameters[param]
       puts "Key: #{param} - Value: #{value}"
@@ -304,7 +304,7 @@ class Prometheus::Base
       end
       ret.merge!( "#{param}" => value) 
     }
-    exportername = "prometheus_#{self.name}_on_#{self.host}_port_#{self.port}"
+    exportername = "prometheus_#{self.name}_on_#{self.host_name}_port_#{self.port}"
     ret.merge!( "exporter_name" => exportername)
     ret
   end

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -304,7 +304,7 @@ class Prometheus::Base
       end
       ret.merge!( "#{param}" => value) 
     }
-    ret.merge! ( "exporter_name" => "prometheus_#{self.name}_on_#{self.host}_port_#{self.port}")
+    ret.merge!( "exporter_name" => "prometheus_#{self.name}_on_#{self.host}_port_#{self.port}")
     puts ret
     ret
   end

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -298,14 +298,12 @@ class Prometheus::Base
     ret = { :targets => [ "#{self.host_name}:#{self.port}" ]}
     @parameters.keys.sort.each { |param|
       value = @parameters[param]
-      puts "Key: #{param} - Value: #{value}"
-      if ["host","port"].include?(param)
+      #puts "Key: #{param} - Value: #{value}"
+      if ["host_name","port"].include?(param)
         next
       end
       ret.merge!( "#{param}" => value) 
     }
-    exportername = "prometheus_#{self.name}_on_#{self.host_name}_port_#{self.port}"
-    ret.merge!( "exporter_name" => exportername)
     ret
   end
 

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -298,7 +298,7 @@ class Prometheus::Base
     ret = { :targets => [ "#{self.host}:#{self.port}" ]}
     @parameters.keys.sort.each { |param|
       value = @parameters[param]
-      #puts "Key: #{param} - Value: #{value}"
+      puts "Key: #{param} - Value: #{value}"
       if ["host","port"].include?(param)
         next
       end

--- a/lib/puppet/external/prometheus/base.rb
+++ b/lib/puppet/external/prometheus/base.rb
@@ -306,7 +306,6 @@ class Prometheus::Base
     }
     exportername = "prometheus_#{self.name}_on_#{self.host}_port_#{self.port}"
     ret.merge!( "exporter_name" => exportername)
-    puts ret
     ret
   end
 
@@ -321,7 +320,8 @@ class Prometheus::Base
 
   # object types
   newtype :host do
-    setparameters :exporter_name, :host, :labels, :port
+    setparameters :title, :host, :labels, :port
+    setnamevar :title
   end
 
 end


### PR DESCRIPTION
- sets `namevar` for the resource (`host_name` was being selected as the namevar)
- ignore `exporter_name` in hash object 